### PR TITLE
Here's a few more global attributes to pull from the yaml files

### DIFF
--- a/cioos_yaml_to_erddap/__main__.py
+++ b/cioos_yaml_to_erddap/__main__.py
@@ -34,7 +34,7 @@ def main():
     filename = args.yaml_file
 
     # write xml snippet
-    with open(filename) as stream:
+    with open(filename, encoding="utf-8") as stream:
         record = yaml.safe_load(stream)
         xml = create_xml_snippet(record)
         print(xml)

--- a/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
+++ b/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
@@ -100,10 +100,10 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
         #    "acknowledgement": "",
         #    "cdm_data_type": "",
         "comment":get_in_language(
-            record["metadata"]["comment"], language
+            record["metadata"].get("comment"), language
         ),
         f"comment_{language_alt}": get_in_language(
-            record["metadata"]["comment"], language_alt
+            record["metadata"].get("comment"), language_alt
         ),
         "contributor_name": ",".join(contributor_names or []),
         "contributor_role": ",".join(contributor_roles or []),

--- a/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
+++ b/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
@@ -27,9 +27,10 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
 
     # Define Info URL and id
     infoUrl = None
-    if record['identification'].get("identifier"):
-        infoUrl = 'https://www.doi.org/' + record['identification']["identifier"]
-        id = record['identification']["identifier"]
+    if record["identification"].get("identifier"):
+        doi = record["identification"]["identifier"]
+        infoUrl = f"https://www.doi.org/{doi}" if "doi.org" not in doi else doi
+        id = record["identification"]["identifier"]
         naming_authority = "org.doi"
     else:
         # Link to National CIOOS, don't think we can link to the upstream CKAN

--- a/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
+++ b/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
@@ -140,8 +140,8 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
         "keywords": ",".join(
             list(
                 set(
-                    record["identification"]["keywords"]["default"]["en"]
-                    + record["identification"]["keywords"]["eov"]["en"]
+                    record["identification"]["keywords"]["default"][language]
+                    + record["identification"]["keywords"]["eov"][language]
                 )
             )
         ),

--- a/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
+++ b/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
@@ -34,8 +34,11 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
         naming_authority = "org.doi"
     else:
         # Link to National CIOOS, don't think we can link to the upstream CKAN
-        infoUrl = "https://catalogue.cioos.ca/en/dataset/ca-cioos_" + record['metadata']["identifier"]
-        id = record['metadata']["identifier"]
+        infoUrl = (
+            "https://catalogue.cioos.ca/en/dataset/ca-cioos_"
+            + record["metadata"]["identifier"]
+        )
+        id = record["metadata"]["identifier"]
         naming_authority = record["metadata"]["naming_autority"]
 
     # Get all organizations
@@ -100,9 +103,7 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
         #    "Conventions": "",
         #    "acknowledgement": "",
         #    "cdm_data_type": "",
-        "comment":get_in_language(
-            record["metadata"].get("comment"), language
-        ),
+        "comment": get_in_language(record["metadata"].get("comment"), language),
         f"comment_{language_alt}": get_in_language(
             record["metadata"].get("comment"), language_alt
         ),
@@ -130,7 +131,7 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
         #    "geospatial_vertical_positive": "",
         #    "geospatial_vertical_resolution": "",
         #    "geospatial_vertical_units": "",
-        "history": record['metadata'].get("history"),
+        "history": record["metadata"].get("history"),
         "id": id,
         "naming_authority": naming_authority,
         "institution": ",".join(organizations or []),
@@ -162,7 +163,7 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
             record["metadata"].get("use_constraints", {}).get("limitations"), language
         ),
         "keywords_vocabulary": "GOOS/CIOOS EOVS",
-        "doi": record['identification'].get("identifier"),
+        "doi": record["identification"].get("identifier"),
         #    "metadata_link": "",
         "platform": record.get("platform", {}).get("name"),
         #    "platform_vocabulary": "",

--- a/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
+++ b/cioos_yaml_to_erddap/yaml_to_erddap_snippet.py
@@ -162,7 +162,7 @@ def yaml_to_erddap_dict(record: Dict) -> Dict:
         "limitations": get_in_language(
             record["metadata"].get("use_constraints", {}).get("limitations"), language
         ),
-        "keywords_vocabulary": "GOOS/CIOOS EOVS",
+        "keywords_vocabulary": "GOOS: Global Ocean Observing System essential ocean variables",
         "doi": record["identification"].get("identifier"),
         #    "metadata_link": "",
         "platform": record.get("platform", {}).get("name"),


### PR DESCRIPTION
This PR adds a few more mapping from the CIOOS Metadata Form YAML format to ERDDAP XML. 

One of the most significant changes is if a DOI is associated with a metadata record. The attributes `doi` and `id` gets the doi code while the  `naming_authoriy` = `org.doi`. `infoUrl` gets the full DOI link.

Otherwise the id and naming_authority fields gets the CIOOS id 

```python
if record['identification'].get("identifier"):
    infoUrl = 'https://www.doi.org/' + record['identification']["identifier"]
    id = record['identification']["identifier"]
    naming_authority = "org.doi"
else:
    # Link to National CIOOS, don't think we can link to the upstream CKAN
    infoUrl = "https://catalogue.cioos.ca/en/dataset/ca-cioos_" + record['metadata']["identifier"]
    id = record['metadata']["identifier"]
    naming_authority = record["metadata"]["naming_autority"]
```